### PR TITLE
Add annotation based injection method

### DIFF
--- a/src/com/uwsoft/editor/renderer/Overlap2D.java
+++ b/src/com/uwsoft/editor/renderer/Overlap2D.java
@@ -1,0 +1,8 @@
+package com.uwsoft.editor.renderer;
+
+import java.lang.annotation.Retention;
+import static java.lang.annotation.RetentionPolicy.*;
+
+public @Retention(RUNTIME) @interface Overlap2D {
+
+}

--- a/src/com/uwsoft/editor/renderer/SceneLoader.java
+++ b/src/com/uwsoft/editor/renderer/SceneLoader.java
@@ -268,4 +268,41 @@ public class SceneLoader {
     public CompositeItem getRoot() {
         return sceneActor;
     }
+	/**
+	 * Injects elements loaded through this scene loader into properly annotated
+	 * fields
+	 * 
+	 * @param object
+	 */
+	@SuppressWarnings("unchecked")
+	public void inject(Object object) {
+		Class<?> cls = object.getClass();
+		// get all public fields
+		Field[] fields = cls.getDeclaredFields();
+		System.out.println(fields.length);
+		// iterate over fields, injecting values from the root composite item
+		// into the object
+		for (Field field : fields) {
+			System.out.println(field.getName());
+			if (IBaseItem.class.isAssignableFrom(field.getType())) {
+				Class<? extends IBaseItem> type = (Class<? extends IBaseItem>) field
+						.getType();
+				Class<?> realType = field.getType();
+				System.out.println(Arrays.toString(field
+						.getDeclaredAnnotations()));
+				if (field.isAnnotationPresent(Overlap2D.class)) {
+					System.out.println("annotation found");
+					String name = field.getName();
+					IBaseItem result = getRoot().getById(name, type);
+					System.out.println(result);
+					try {
+						field.set(object, realType.cast(result));
+					} catch (IllegalArgumentException | IllegalAccessException e) {
+						e.printStackTrace();
+						System.exit(-1);
+					}
+				}
+			}
+		}
+	}
 }

--- a/src/com/uwsoft/editor/renderer/actor/CompositeItem.java
+++ b/src/com/uwsoft/editor/renderer/actor/CompositeItem.java
@@ -929,5 +929,8 @@ public class CompositeItem extends Group implements IBaseItem {
     public CustomVariables getCustomVariables() {
         return customVariables;
     }
+	public <T extends IBaseItem> T getById(String itemId, Class<T> itemType) {
+		return itemType.cast(itemIdMap.get(itemId));
+	}
 
 }


### PR DESCRIPTION
Works like JavaFX, you can easily keep all the main elements you wish to
store as instance variables as annotated fields.  It casts the elements
based on compatibility, so if the item loaded from your Overlap2D
project does not match the field type, your application will crash.

Injection works with any object type, not just stages, so you can inject
into simple struct like objects or more.  Injection may only be called
after the scene loader has loaded a scene.

Really this is only done as a fun convenience.
