### PR TITLE
Fixed a memory leak caused by CompositeItem.itemLayerMap holding a

### DIFF
--- a/src/com/uwsoft/editor/renderer/actor/CompositeItem.java
+++ b/src/com/uwsoft/editor/renderer/actor/CompositeItem.java
@@ -698,6 +698,13 @@ public class CompositeItem extends Group implements IBaseItem {
      */
     public void removeItem(IBaseItem item) {
         items.remove(item);
+        
+        // Removes the item from the itemLayerMap
+        ArrayList<IBaseItem> itemLayer = itemLayerMap.get(item.getDataVO().layerName);
+        if(itemLayer != null) {
+        	itemLayer.remove(item);
+        }
+        
         dataVO.composite.removeItem(item.getDataVO());
         item.dispose();
     }


### PR DESCRIPTION
Fixed a memory leak caused by CompositeItem.itemLayerMap holding a
reference to the IBaseItem being removed from the parent item.