### PR TITLE
fixed: layer unhiding not affecting layer's items

### DIFF
--- a/src/com/uwsoft/editor/renderer/systems/LayerSystem.java
+++ b/src/com/uwsoft/editor/renderer/systems/LayerSystem.java
@@ -58,9 +58,7 @@ public class LayerSystem extends IteratingSystem {
 			}
 			if(layerMapComponent.getLayer(zindexComponent.layerName) != null) {
                 boolean isLayerVisible = layerMapComponent.getLayer(zindexComponent.layerName).isVisible;
-                if(mainItemComponent.visible) {
-                    mainItemComponent.visible = isLayerVisible;
-                }
+				mainItemComponent.visible = isLayerVisible;
 			}
         }
 	}


### PR DESCRIPTION
fixing UnderwaterApps/overlap2d#216