### PR TITLE
squid:S1155 - Collection.isEmpty() should be used to test for emptiness

### DIFF
--- a/src/com/brashmonkey/spriter/XmlReader.java
+++ b/src/com/brashmonkey/spriter/XmlReader.java
@@ -287,7 +287,7 @@ public class XmlReader {
 				if (data[i] == '\n') lineNumber++;
 			throw new SpriterException("Error parsing XML on line " + lineNumber + " near: "
 				+ new String(data, p, Math.min(32, pe - p)));
-		} else if (elements.size() != 0) {
+		} else if (!elements.isEmpty()) {
 			Element element = elements.get(elements.size()-1);
 			elements.clear();
 			throw new SpriterException("Error parsing XML, unclosed element: " + element.getName());
@@ -404,7 +404,7 @@ public class XmlReader {
 	protected void close () {
 		root = elements.get(elements.size()-1);
 		elements.remove(elements.size()-1);
-		current = elements.size() > 0 ? elements.get(elements.size()-1) : null;
+		current = !elements.isEmpty() ? elements.get(elements.size()-1) : null;
 	}
 
 	static public class Element {

--- a/src/com/uwsoft/editor/renderer/data/CompositeVO.java
+++ b/src/com/uwsoft/editor/renderer/data/CompositeVO.java
@@ -188,19 +188,19 @@ public class CompositeVO {
     }
 
     public boolean isEmpty() {
-        return sComposites.size() == 0 &&
-                sImage9patchs.size() == 0 &&
-                sImages.size() == 0 &&
-                sSpriteAnimations.size() == 0 &&
-                sLabels.size() == 0 &&
-                sLights.size() == 0 &&
-                sParticleEffects.size() == 0 &&
-                sSpriteAnimations.size() == 0 &&
-                sSpriterAnimations.size() == 0 &&
-                sSpineAnimations.size() == 0 &&
-                sSelectBoxes.size() == 0 &&
-                sTextBox.size() == 0 &&
-                sColorPrimitives.size() == 0;
+        return sComposites.isEmpty() &&
+                sImage9patchs.isEmpty() &&
+                sImages.isEmpty() &&
+                sSpriteAnimations.isEmpty() &&
+                sLabels.isEmpty() &&
+                sLights.isEmpty() &&
+                sParticleEffects.isEmpty() &&
+                sSpriteAnimations.isEmpty() &&
+                sSpriterAnimations.isEmpty() &&
+                sSpineAnimations.isEmpty() &&
+                sSelectBoxes.isEmpty() &&
+                sTextBox.isEmpty() &&
+                sColorPrimitives.isEmpty();
     }
 
     public String[] getRecursiveParticleEffectsList() {

--- a/src/com/uwsoft/editor/renderer/utils/PolygonUtils.java
+++ b/src/com/uwsoft/editor/renderer/utils/PolygonUtils.java
@@ -37,7 +37,7 @@ public class PolygonUtils {
         uniqueEdges.removeAll(duplicateEdges);
 
         Array<Vector2[]> result = new Array<Vector2[]>();
-        while(uniqueEdges.size() > 0) {
+        while(!uniqueEdges.isEmpty()) {
             Vector2[] mesh = extractClosedLoop(uniqueEdges);
             mesh = clearUnnecessaryVertices(mesh);
             result.add(mesh);
@@ -74,10 +74,10 @@ public class PolygonUtils {
         Edge edge = (Edge) edges.toArray()[0];
         edges.remove(edge);
         sortedList.add(edge);
-        while(edges.size() > 0) {
+        while(!edges.isEmpty()) {
             boolean result2 = false;
             boolean result1 = appendNextEdge(sortedList, edges);
-            if(edges.size() > 0) {
+            if(!edges.isEmpty()) {
                 result2 = appendPrevEdge(sortedList, edges);
             }
             if(!result1 && !result2) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1155 - Collection.isEmpty() should be used to test for emptiness

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1155

Please let me know if you have any questions.

M-Ezzat