### PR TITLE
squid:S1125 - Literal boolean values should not be used in condition …

### DIFF
--- a/src/com/uwsoft/editor/renderer/SceneLoader.java
+++ b/src/com/uwsoft/editor/renderer/SceneLoader.java
@@ -379,7 +379,7 @@ public class SceneLoader {
 			+ "}";
 
 		ShaderProgram shader = new ShaderProgram(vertexShader, fragmentShader);
-		if (shader.isCompiled() == false) throw new IllegalArgumentException("Error compiling shader: " + shader.getLog());
+		if (!shader.isCompiled()) throw new IllegalArgumentException("Error compiling shader: " + shader.getLog());
 		return shader;
 	}
 

--- a/src/com/uwsoft/editor/renderer/components/additional/ButtonComponent.java
+++ b/src/com/uwsoft/editor/renderer/components/additional/ButtonComponent.java
@@ -32,12 +32,12 @@ public class ButtonComponent implements Component {
     }
 
     public void setTouchState(boolean isTouched) {
-        if(this.isTouched == false && isTouched == true) {
+        if(!this.isTouched && isTouched) {
             for(int i = 0; i < listeners.size; i++) {
                 listeners.get(i).touchDown();
             }
         }
-        if(this.isTouched == true && isTouched == false) {
+        if(this.isTouched && !isTouched) {
             for(int i = 0; i < listeners.size; i++) {
                 listeners.get(i).touchUp();
                 listeners.get(i).clicked();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1125 - Literal boolean values should not be used in condition expressions

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1125

Please let me know if you have any questions.

M-Ezzat