### PR TITLE
Fix transforms not working with physics composites objects

### DIFF
--- a/src/com/uwsoft/editor/renderer/SceneLoader.java
+++ b/src/com/uwsoft/editor/renderer/SceneLoader.java
@@ -181,6 +181,7 @@ public class SceneLoader {
 		LightSystem lightSystem = new LightSystem();
 		SpriteAnimationSystem animationSystem = new SpriteAnimationSystem();
 		LayerSystem layerSystem = new LayerSystem();
+		TransformSystem transformSystem = new TransformSystem();
 		PhysicsSystem physicsSystem = new PhysicsSystem(world);
 		CompositeSystem compositeSystem = new CompositeSystem();
 		LabelSystem labelSystem = new LabelSystem();
@@ -194,6 +195,7 @@ public class SceneLoader {
 		engine.addSystem(particleSystem);
 		engine.addSystem(lightSystem);
 		engine.addSystem(layerSystem);
+		engine.addSystem(transformSystem);
 		engine.addSystem(physicsSystem);
 		engine.addSystem(compositeSystem);
 		engine.addSystem(labelSystem);

--- a/src/com/uwsoft/editor/renderer/components/TransformComponent.java
+++ b/src/com/uwsoft/editor/renderer/components/TransformComponent.java
@@ -5,6 +5,8 @@ import com.badlogic.ashley.core.Component;
 public class TransformComponent implements Component {
 	public float x; 
 	public float y;
+	public float offsetX;
+	public float offsetY;
 	public float scaleX	=	1f; 
 	public float scaleY	=	1f;
 	public float rotation;

--- a/src/com/uwsoft/editor/renderer/physics/PhysicsBodyLoader.java
+++ b/src/com/uwsoft/editor/renderer/physics/PhysicsBodyLoader.java
@@ -54,7 +54,7 @@ public class PhysicsBodyLoader {
         }
 
         BodyDef bodyDef = new BodyDef();
-        bodyDef.position.set((transformComponent.x + transformComponent.originX) * PhysicsBodyLoader.getScale(), (transformComponent.y + transformComponent.originY) * PhysicsBodyLoader.getScale());
+        bodyDef.position.set((transformComponent.offsetX + transformComponent.originX) * PhysicsBodyLoader.getScale(), (transformComponent.offsetY + transformComponent.originY) * PhysicsBodyLoader.getScale());
         bodyDef.angle = transformComponent.rotation * MathUtils.degreesToRadians;
 
         bodyDef.awake = physicsComponent.awake;

--- a/src/com/uwsoft/editor/renderer/systems/PhysicsSystem.java
+++ b/src/com/uwsoft/editor/renderer/systems/PhysicsSystem.java
@@ -49,8 +49,8 @@ public class PhysicsSystem extends IteratingSystem {
 
 		PhysicsBodyComponent physicsBodyComponent = ComponentRetriever.get(entity, PhysicsBodyComponent.class);
 		Body body = physicsBodyComponent.body;
-		transformComponent.x = body.getPosition().x / PhysicsBodyLoader.getScale() - transformComponent.originX;
-		transformComponent.y = body.getPosition().y / PhysicsBodyLoader.getScale() - transformComponent.originY;
+		transformComponent.offsetX = body.getPosition().x / PhysicsBodyLoader.getScale() - transformComponent.originX;
+		transformComponent.offsetY = body.getPosition().y / PhysicsBodyLoader.getScale() - transformComponent.originY;
 		transformComponent.rotation = body.getAngle() * MathUtils.radiansToDegrees;
 	}
 

--- a/src/com/uwsoft/editor/renderer/systems/TransformSystem.java
+++ b/src/com/uwsoft/editor/renderer/systems/TransformSystem.java
@@ -1,0 +1,79 @@
+package com.uwsoft.editor.renderer.systems;
+
+import com.badlogic.ashley.core.ComponentMapper;
+import com.badlogic.ashley.core.Entity;
+import com.badlogic.ashley.core.Family;
+import com.badlogic.ashley.systems.IteratingSystem;
+import com.uwsoft.editor.renderer.components.*;
+
+/**
+ * Created by aurel on 25/02/16.
+ */
+public class TransformSystem extends IteratingSystem {
+
+    private ComponentMapper<ViewPortComponent> viewPortMapper = ComponentMapper.getFor(ViewPortComponent.class);
+    private ComponentMapper<CompositeTransformComponent> compositeTransformMapper = ComponentMapper.getFor(CompositeTransformComponent.class);
+    private ComponentMapper<NodeComponent> nodeMapper = ComponentMapper.getFor(NodeComponent.class);
+    private ComponentMapper<TransformComponent> transformMapper = ComponentMapper.getFor(TransformComponent.class);
+
+    public TransformSystem() {
+        super(Family.all(ViewPortComponent.class).get());
+    }
+
+    @Override
+    protected void processEntity(Entity entity, float deltaTime) {
+        computeCompositeTransformsRecursively(entity);
+    }
+
+    private void computeCompositeTransformsRecursively(Entity compositeEntity) {
+        CompositeTransformComponent curCompositeTransformComponent = compositeTransformMapper.get(compositeEntity);
+
+        computeChildrenTransforms(compositeEntity, curCompositeTransformComponent);
+    }
+
+    private void computeChildrenTransforms(Entity rootEntity, CompositeTransformComponent curCompositeTransformComponent) {
+        NodeComponent nodeComponent = nodeMapper.get(rootEntity);
+        Entity[] children = nodeComponent.children.begin();
+        TransformComponent transform = transformMapper.get(rootEntity);
+
+        if (curCompositeTransformComponent.transform || transform.rotation != 0 || transform.scaleX !=1 || transform.scaleY !=1) {
+            for (int i = 0, n = nodeComponent.children.size; i < n; i++) {
+                Entity child = children[i];
+
+                NodeComponent childNodeComponent = nodeMapper.get(child);
+
+                if(childNodeComponent != null){
+                    //Step into Composite
+                    computeCompositeTransformsRecursively(child);
+                }
+            }
+        }
+        else {
+            // No transform for this group, offset each child.
+            TransformComponent compositeTransform = transformMapper.get(rootEntity);
+            float offsetX = compositeTransform.offsetX, offsetY = compositeTransform.offsetY;
+
+            if(viewPortMapper.has(rootEntity)){
+                offsetX = 0;
+                offsetY = 0;
+            }
+
+            for (int i = 0, n = nodeComponent.children.size; i < n; i++) {
+                Entity child = children[i];
+
+                TransformComponent childTransformComponent = transformMapper.get(child);
+
+                childTransformComponent.offsetX = childTransformComponent.x + offsetX;
+                childTransformComponent.offsetY = childTransformComponent.y + offsetY;
+
+                NodeComponent childNodeComponent = nodeMapper.get(child);
+
+                if(childNodeComponent != null){
+                    //Step into Composite
+                    computeCompositeTransformsRecursively(child);
+                }
+
+            }
+        }
+    }
+}

--- a/src/com/uwsoft/editor/renderer/systems/render/Overlap2dRenderer.java
+++ b/src/com/uwsoft/editor/renderer/systems/render/Overlap2dRenderer.java
@@ -132,14 +132,6 @@ public class Overlap2dRenderer extends IteratingSystem {
 			}
 		} else {
 			// No transform for this group, offset each child.
-			TransformComponent compositeTransform = transformMapper.get(rootEntity);
-			
-			float offsetX = compositeTransform.x, offsetY = compositeTransform.y;
-			
-			if(viewPortMapper.has(rootEntity)){
-				offsetX = 0;
-				offsetY = 0;
-			}
 			
 			for (int i = 0, n = nodeComponent.children.size; i < n; i++) {
 				Entity child = children[i];
@@ -155,11 +147,6 @@ public class Overlap2dRenderer extends IteratingSystem {
 				if(!childMainItemComponent.visible){
 					continue;
 				}
-
-				TransformComponent childTransformComponent = transformMapper.get(child);
-				float cx = childTransformComponent.x, cy = childTransformComponent.y;
-				childTransformComponent.x = cx + offsetX;
-				childTransformComponent.y = cy + offsetY;
 				
 				NodeComponent childNodeComponent = nodeMapper.get(child);
 				int entityType = mainItemComponentMapper.get(child).entityType;
@@ -171,8 +158,6 @@ public class Overlap2dRenderer extends IteratingSystem {
 					//Step into Composite
 					drawRecursively(child, parentAlpha);
 				}
-				childTransformComponent.x = cx;
-				childTransformComponent.y = cy;
 			}
 		}
 		nodeComponent.children.end();

--- a/src/com/uwsoft/editor/renderer/systems/render/logic/LabelDrawableLogic.java
+++ b/src/com/uwsoft/editor/renderer/systems/render/logic/LabelDrawableLogic.java
@@ -39,7 +39,7 @@ public class LabelDrawableLogic implements Drawable {
 
 		if (labelComponent.style.background != null) {
 			batch.setColor(tmpColor);
-			labelComponent.style.background.draw(batch, entityTransformComponent.x, entityTransformComponent.y, dimenstionsComponent.width, dimenstionsComponent.height);
+			labelComponent.style.background.draw(batch, entityTransformComponent.offsetX, entityTransformComponent.offsetY, dimenstionsComponent.width, dimenstionsComponent.height);
 			//System.out.println("LAbel BG");
 		}
 

--- a/src/com/uwsoft/editor/renderer/systems/render/logic/NinePatchDrawableLogic.java
+++ b/src/com/uwsoft/editor/renderer/systems/render/logic/NinePatchDrawableLogic.java
@@ -29,7 +29,7 @@ public class NinePatchDrawableLogic implements Drawable {
 		NinePatchComponent entityNinePatchComponent = ninePatchMapper.get(entity);
 		batch.setColor(tintComponent.color);
 
-		entityNinePatchComponent.ninePatch.draw(batch, entityTransformComponent.x, entityTransformComponent.y, entityDimensionsComponent.width, entityDimensionsComponent.height);
+		entityNinePatchComponent.ninePatch.draw(batch, entityTransformComponent.offsetX, entityTransformComponent.offsetY, entityDimensionsComponent.width, entityDimensionsComponent.height);
 	}
 
 }

--- a/src/com/uwsoft/editor/renderer/systems/render/logic/ParticleDrawableLogic.java
+++ b/src/com/uwsoft/editor/renderer/systems/render/logic/ParticleDrawableLogic.java
@@ -21,7 +21,7 @@ public class ParticleDrawableLogic implements Drawable {
 		//batch.setTransformMatrix(matrix);
 		TransformComponent transformComponent = transformComponentMapper.get(entity);
 		//particleEffect.setPosition(transformComponent.x/particleComponent.worldMultiplyer, transformComponent.y/particleComponent.worldMultiplyer);
-		particleComponent.particleEffect.setPosition(transformComponent.x, transformComponent.y);
+		particleComponent.particleEffect.setPosition(transformComponent.offsetX, transformComponent.offsetY);
 		particleComponent.particleEffect.draw(batch);
 		//batch.setTransformMatrix(batch.getTransformMatrix().scl(1f/particleComponent.worldMultiplyer));
 	}

--- a/src/com/uwsoft/editor/renderer/systems/render/logic/SpriterDrawableLogic.java
+++ b/src/com/uwsoft/editor/renderer/systems/render/logic/SpriterDrawableLogic.java
@@ -27,7 +27,7 @@ public class SpriterDrawableLogic implements Drawable {
 		SpriterComponent spriter = spriterMapper.get(entity);
 		Player player = spriter.player;
 		
-		player.setPosition(entityTransformComponent.x, entityTransformComponent.y);
+		player.setPosition(entityTransformComponent.offsetX, entityTransformComponent.offsetY);
 		//TODO dimentions 
 		//player.setPivot(getWidth() / 2, getHeight() / 2);
 		player.setScale(spriter.scale );

--- a/src/com/uwsoft/editor/renderer/systems/render/logic/TexturRegionDrawLogic.java
+++ b/src/com/uwsoft/editor/renderer/systems/render/logic/TexturRegionDrawLogic.java
@@ -71,7 +71,7 @@ public class TexturRegionDrawLogic implements Drawable {
         batch.setColor(tintComponent.color.r, tintComponent.color.g, tintComponent.color.b, tintComponent.color.a * parentAlpha);
 
         batch.draw(entityTextureRegionComponent.region,
-                entityTransformComponent.x, entityTransformComponent.y,
+                entityTransformComponent.offsetX, entityTransformComponent.offsetY,
                 entityTransformComponent.originX, entityTransformComponent.originY,
                 dimensionsComponent.width, dimensionsComponent.height,
                 entityTransformComponent.scaleX, entityTransformComponent.scaleY,


### PR DESCRIPTION
This PR fix the issue  #81.

The transforms offset computing are now moved from `Overlap2dRenderer` to a `TransformSystem` system that is processed before the `PhysicsSystem` and `Overlap2dRenderer`.

I tested the fix in runtime and in the editor.