### PR TITLE
(Quickfix) SprinteAnimation IndexOutOfBoundsException: index can't be >= size: 0 >= 0

### DIFF
--- a/src/com/uwsoft/editor/renderer/factory/component/SpriteComponentFactory.java
+++ b/src/com/uwsoft/editor/renderer/factory/component/SpriteComponentFactory.java
@@ -124,11 +124,15 @@ public class SpriteComponentFactory extends ComponentFactory {
     }
 
     private Array<TextureAtlas.AtlasRegion> getRegions(String filter) {
+        // At import time, it gets renamed to spritenamePack, but
+        // region.name.contains won't match spritenamePack
+        // but it will match only spriteName, so we remove it
+        String tmp = filter.replace("Pack", "");
         // filtering regions by name
         Array<TextureAtlas.AtlasRegion> allRegions = rm.getSpriteAnimation(filter).getRegions();
         Array<TextureAtlas.AtlasRegion> regions = new Array<TextureAtlas.AtlasRegion>();
         for(TextureAtlas.AtlasRegion region: allRegions) {
-            if(region.name.contains(filter)) {
+            if(region.name.contains(tmp)) {
                 regions.add(region);
             }
         }


### PR DESCRIPTION
Quickfix for ``` java.lang.IndexOutOfBoundsException: index can't be >= size: 0 >= 0```  error at using imported sprite animations on Overlap2D.


**Error replication steps**

1. Open/Import Overlap2D project
2. Import a sprite animation (optional)
3. Drag/Drop animation to scene

It caused a force close and this was the output to stdout:
``` java
java.lang.IndexOutOfBoundsException: index can't be >= size: 0 >= 0
        at com.badlogic.gdx.utils.Array.get(Array.java:127)
        at com.uwsoft.editor.renderer.factory.component.SpriteComponentFactory.createDimensionsComponent(SpriteComponentFactory.java:71)
        at com.uwsoft.editor.renderer.factory.component.ComponentFactory.createCommonComponents(ComponentFactory.java:64)
        at com.uwsoft.editor.renderer.factory.component.SpriteComponentFactory.createComponents(SpriteComponentFactory.java:55)
        at com.uwsoft.editor.renderer.factory.EntityFactory.createEntity(EntityFactory.java:152)
        at com.uwsoft.editor.factory.ItemFactory.createSpriteAnimation(ItemFactory.java:113)
        at com.uwsoft.editor.view.ui.box.resourcespanel.draggable.DraggableResource.drop(DraggableResource.java:86)
        at com.uwsoft.editor.view.ui.box.resourcespanel.draggable.DraggableResource.access$100(DraggableResource.java:36)
        at com.uwsoft.editor.view.ui.box.resourcespanel.draggable.DraggableResource$2.drop(DraggableResource.java:76)
        at com.badlogic.gdx.scenes.scene2d.utils.DragAndDrop$1.dragStop(DragAndDrop.java:138)
        at com.badlogic.gdx.scenes.scene2d.utils.DragListener.touchUp(DragListener.java:64)
        at com.badlogic.gdx.scenes.scene2d.InputListener.handle(InputListener.java:58)
        at com.badlogic.gdx.scenes.scene2d.Stage.touchUp(Stage.java:348)
        at com.badlogic.gdx.InputMultiplexer.touchUp(InputMultiplexer.java:96)
        at com.badlogic.gdx.backends.lwjgl.LwjglInput.processEvents(LwjglInput.java:316)
        at com.badlogic.gdx.backends.lwjgl.LwjglCanvas$3.run(LwjglCanvas.java:234)
        at java.awt.event.InvocationEvent.dispatch(Unknown Source)
        at java.awt.EventQueue.dispatchEventImpl(Unknown Source)
        at java.awt.EventQueue.access$500(Unknown Source)
        at java.awt.EventQueue$3.run(Unknown Source)
        at java.awt.EventQueue$3.run(Unknown Source)
        at java.security.AccessController.doPrivileged(Native Method)
        at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(Unknown Source)
        at java.awt.EventQueue.dispatchEvent(Unknown Source)
        at java.awt.EventDispatchThread.pumpOneEventForFilters(Unknown Source)
        at java.awt.EventDispatchThread.pumpEventsForFilter(Unknown Source)
        at java.awt.EventDispatchThread.pumpEventsForHierarchy(Unknown Source)
        at java.awt.EventDispatchThread.pumpEvents(Unknown Source)
        at java.awt.EventDispatchThread.pumpEvents(Unknown Source)
        at java.awt.EventDispatchThread.run(Unknown Source)
Exception in thread "AWT-EventQueue-0" java.lang.RuntimeException: No OpenGL context found in the current thread.
        at org.lwjgl.opengl.GLContext.getCapabilities(GLContext.java:124)
        at org.lwjgl.opengl.GL11.glDeleteTextures(GL11.java:732)
        at com.badlogic.gdx.backends.lwjgl.LwjglGL20.glDeleteTexture(LwjglGL20.java:248)
        at com.badlogic.gdx.graphics.GLTexture.delete(GLTexture.java:170)
        at com.badlogic.gdx.graphics.Texture.dispose(Texture.java:194)
        at com.badlogic.gdx.graphics.g2d.TextureAtlas.dispose(TextureAtlas.java:418)
        at com.badlogic.gdx.scenes.scene2d.ui.Skin.dispose(Skin.java:389)
        at com.kotcrab.vis.ui.VisUI.dispose(VisUI.java:114)
        at com.uwsoft.editor.Overlap2D.dispose(Overlap2D.java:68)
        at com.badlogic.gdx.backends.lwjgl.LwjglCanvas$4.run(LwjglCanvas.java:309)
        at java.awt.event.InvocationEvent.dispatch(Unknown Source)
        at java.awt.EventQueue.dispatchEventImpl(Unknown Source)
        at java.awt.EventQueue.access$500(Unknown Source)
        at java.awt.EventQueue$3.run(Unknown Source)
        at java.awt.EventQueue$3.run(Unknown Source)
        at java.security.AccessController.doPrivileged(Native Method)
        at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(Unknown Source)
        at java.awt.EventQueue.dispatchEvent(Unknown Source)
        at java.awt.EventDispatchThread.pumpOneEventForFilters(Unknown Source)
        at java.awt.EventDispatchThread.pumpEventsForFilter(Unknown Source)
        at java.awt.EventDispatchThread.pumpEventsForHierarchy(Unknown Source)
        at java.awt.EventDispatchThread.pumpEvents(Unknown Source)
        at java.awt.EventDispatchThread.pumpEvents(Unknown Source)
        at java.awt.EventDispatchThread.run(Unknown Source)
```

That because in ```SpriteComponentFactory```, the ```getRegions()``` function searches for regions that contains **spritenamePack**, when in fact it should be searching only for **spritename**.

Ej:

Sprites: megaman01.png, megaman02...
Region names: megaman01, megaman02...
Packed Atlas name: megamanPack
filter: megamanPack

It matches the region names with ```region.name.contains(filter)``` so the region name will never contain **spritenamePack** but it will contain **spritename**