### PR TITLE
squid:S1213 - The members of an interface declaration or class should…

### DIFF
--- a/src/com/uwsoft/editor/renderer/components/light/LightObjectComponent.java
+++ b/src/com/uwsoft/editor/renderer/components/light/LightObjectComponent.java
@@ -8,10 +8,6 @@ import com.uwsoft.editor.renderer.physics.PhysicsBodyLoader;
 
 public class LightObjectComponent implements Component {
 	private LightType type;
-	
-	public LightObjectComponent(LightType type) {
-		this.type = type;
-	}
 
 	public int rays = 12;
 	public float distance = 300;
@@ -21,6 +17,10 @@ public class LightObjectComponent implements Component {
 	public boolean isStatic = true;
 	public boolean isXRay = true;
 	public Light lightObject = null;
+
+	public LightObjectComponent(LightType type) {
+		this.type = type;
+	}
 
 	public LightType getType(){
 		return type;

--- a/src/com/uwsoft/editor/renderer/factory/EntityFactory.java
+++ b/src/com/uwsoft/editor/renderer/factory/EntityFactory.java
@@ -40,6 +40,24 @@ public class EntityFactory {
 	public World world;
 	public IResourceRetriever rm = null;
 
+	public EntityFactory( RayHandler rayHandler, World world, IResourceRetriever rm ) {
+
+		this.rayHandler = rayHandler;
+		this.world = world;
+		this.rm = rm;
+
+		compositeComponentFactory = new CompositeComponentFactory(rayHandler, world, rm);
+		lightComponentFactory = new LightComponentFactory(rayHandler, world, rm);
+		particleEffectComponentFactory = new ParticleEffectComponentFactory(rayHandler, world, rm);
+		simpleImageComponentFactory = new SimpleImageComponentFactory(rayHandler, world, rm);
+		spriteComponentFactory = new SpriteComponentFactory(rayHandler, world, rm);
+		spriterComponentFactory = new SpriterComponentFactory(rayHandler, world, rm);
+		labelComponentFactory = new LabelComponentFactory(rayHandler, world, rm);
+		ninePatchComponentFactory = new NinePatchComponentFactory(rayHandler, world, rm);
+		colorPrimitiveFactory = new ColorPrimitiveComponentFactory(rayHandler, world, rm);
+
+	}
+
 	protected ComponentFactory compositeComponentFactory, lightComponentFactory, particleEffectComponentFactory,
 			simpleImageComponentFactory, spriteComponentFactory, spriterComponentFactory, labelComponentFactory, ninePatchComponentFactory, colorPrimitiveFactory;
 
@@ -54,24 +72,6 @@ public class EntityFactory {
     public SpriteComponentFactory getSpriteComponentFactory() {
         return (SpriteComponentFactory) spriteComponentFactory;
     }
-
-	public EntityFactory( RayHandler rayHandler, World world, IResourceRetriever rm ) {
-	
-		this.rayHandler = rayHandler;
-		this.world = world;
-		this.rm = rm;
-
-		compositeComponentFactory = new CompositeComponentFactory(rayHandler, world, rm);
-		lightComponentFactory = new LightComponentFactory(rayHandler, world, rm);
-		particleEffectComponentFactory = new ParticleEffectComponentFactory(rayHandler, world, rm);
-		simpleImageComponentFactory = new SimpleImageComponentFactory(rayHandler, world, rm);
-		spriteComponentFactory = new SpriteComponentFactory(rayHandler, world, rm);
-		spriterComponentFactory = new SpriterComponentFactory(rayHandler, world, rm);
-		labelComponentFactory = new LabelComponentFactory(rayHandler, world, rm);
-		ninePatchComponentFactory = new NinePatchComponentFactory(rayHandler, world, rm);
-		colorPrimitiveFactory = new ColorPrimitiveComponentFactory(rayHandler, world, rm);
-		
-	}
 
 	public void addExternalFactory(IExternalItemType itemType) {
 		externalFactories.put(itemType.getTypeId(), itemType.getComponentFactory());

--- a/src/com/uwsoft/editor/renderer/scene2d/CompositeActor.java
+++ b/src/com/uwsoft/editor/renderer/scene2d/CompositeActor.java
@@ -328,11 +328,6 @@ public class CompositeActor extends Group {
      */
     public interface BuiltItemHandler {
 
-        /**
-         * @param item newly built and added to a parent (in case it's not a root actor)
-         */
-        void onItemBuild(Actor item);
-
         BuiltItemHandler DEFAULT = new BuiltItemHandler() {
             @Override
             public void onItemBuild(Actor item) {
@@ -344,6 +339,12 @@ public class CompositeActor extends Group {
                 }
             }
         };
+
+        /**
+         * @param item newly built and added to a parent (in case it's not a root actor)
+         */
+        void onItemBuild(Actor item);
+
     }
 
     @Override


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1213

Please let me know if you have any questions.

M-Ezzat