### PR TITLE
Fix transforms not working with physics composites objects

### DIFF
--- a/src/com/uwsoft/editor/renderer/physics/PhysicsBodyLoader.java
+++ b/src/com/uwsoft/editor/renderer/physics/PhysicsBodyLoader.java
@@ -1,10 +1,12 @@
 package com.uwsoft.editor.renderer.physics;
 
+import com.badlogic.ashley.core.Entity;
 import com.badlogic.gdx.math.MathUtils;
 import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.physics.box2d.*;
 import com.uwsoft.editor.renderer.components.TransformComponent;
 import com.uwsoft.editor.renderer.components.physics.PhysicsBodyComponent;
+import com.uwsoft.editor.renderer.utils.TransformMathUtils;
 
 /**
  * Created by azakhary on 9/28/2014.
@@ -37,7 +39,7 @@ public class PhysicsBodyLoader {
         return getInstance().scale;
     }
 
-    public Body createBody(World world, PhysicsBodyComponent physicsComponent, Vector2[][] minPolygonData, TransformComponent transformComponent) {
+    public Body createBody(World world, Entity entity, PhysicsBodyComponent physicsComponent, Vector2[][] minPolygonData, TransformComponent transformComponent) {
 
         FixtureDef fixtureDef = new FixtureDef();
 
@@ -54,7 +56,8 @@ public class PhysicsBodyLoader {
         }
 
         BodyDef bodyDef = new BodyDef();
-        bodyDef.position.set((transformComponent.x + transformComponent.originX) * PhysicsBodyLoader.getScale(), (transformComponent.y + transformComponent.originY) * PhysicsBodyLoader.getScale());
+        Vector2 sceneCoords = TransformMathUtils.localToSceneCoordinates(entity, new Vector2(0, 0));
+        bodyDef.position.set(sceneCoords.x * PhysicsBodyLoader.getScale(), sceneCoords.y * PhysicsBodyLoader.getScale());
         bodyDef.angle = transformComponent.rotation * MathUtils.degreesToRadians;
 
         bodyDef.awake = physicsComponent.awake;

--- a/src/com/uwsoft/editor/renderer/physics/PhysicsBodyLoader.java
+++ b/src/com/uwsoft/editor/renderer/physics/PhysicsBodyLoader.java
@@ -57,7 +57,7 @@ public class PhysicsBodyLoader {
 
         BodyDef bodyDef = new BodyDef();
         Vector2 sceneCoords = TransformMathUtils.localToSceneCoordinates(entity, new Vector2(0, 0));
-        bodyDef.position.set(sceneCoords.x * PhysicsBodyLoader.getScale(), sceneCoords.y * PhysicsBodyLoader.getScale());
+        bodyDef.position.set((sceneCoords.x + transformComponent.originX) * PhysicsBodyLoader.getScale() , (sceneCoords.y + transformComponent.originY)* PhysicsBodyLoader.getScale() );
         bodyDef.angle = transformComponent.rotation * MathUtils.degreesToRadians;
 
         bodyDef.awake = physicsComponent.awake;

--- a/src/com/uwsoft/editor/renderer/systems/PhysicsSystem.java
+++ b/src/com/uwsoft/editor/renderer/systems/PhysicsSystem.java
@@ -15,6 +15,7 @@ import com.uwsoft.editor.renderer.components.TransformComponent;
 import com.uwsoft.editor.renderer.components.physics.PhysicsBodyComponent;
 import com.uwsoft.editor.renderer.physics.PhysicsBodyLoader;
 import com.uwsoft.editor.renderer.utils.ComponentRetriever;
+import com.uwsoft.editor.renderer.utils.TransformMathUtils;
 
 public class PhysicsSystem extends IteratingSystem {
 
@@ -49,8 +50,12 @@ public class PhysicsSystem extends IteratingSystem {
 
 		PhysicsBodyComponent physicsBodyComponent = ComponentRetriever.get(entity, PhysicsBodyComponent.class);
 		Body body = physicsBodyComponent.body;
-		transformComponent.x = body.getPosition().x / PhysicsBodyLoader.getScale() - transformComponent.originX;
-		transformComponent.y = body.getPosition().y / PhysicsBodyLoader.getScale() - transformComponent.originY;
+		transformComponent.x = 0;
+		transformComponent.y = 0;
+		transformComponent.rotation = 0;
+		Vector2 localCoords = TransformMathUtils.sceneToLocalCoordinates(entity, body.getPosition().cpy().scl(1 / PhysicsBodyLoader.getScale()));
+		transformComponent.x = localCoords.x - transformComponent.originX;
+		transformComponent.y = localCoords.y - transformComponent.originY;
 		transformComponent.rotation = body.getAngle() * MathUtils.radiansToDegrees;
 	}
 
@@ -73,7 +78,7 @@ public class PhysicsSystem extends IteratingSystem {
             physicsBodyComponent.centerY = dimensionsComponent.height/2;
 
 			PhysicsBodyComponent bodyPropertiesComponent = ComponentRetriever.get(entity, PhysicsBodyComponent.class);
-			physicsBodyComponent.body = PhysicsBodyLoader.getInstance().createBody(world, bodyPropertiesComponent, polygonComponent.vertices, transformComponent);
+			physicsBodyComponent.body = PhysicsBodyLoader.getInstance().createBody(world, entity, bodyPropertiesComponent, polygonComponent.vertices, transformComponent);
 
 			physicsBodyComponent.body.setUserData(entity);
 		}

--- a/src/com/uwsoft/editor/renderer/utils/TransformMathUtils.java
+++ b/src/com/uwsoft/editor/renderer/utils/TransformMathUtils.java
@@ -48,13 +48,13 @@ public class TransformMathUtils {
 
 	/** Converts the coordinates given in the parent's coordinate system to this entity's coordinate system. */
 	public static Vector2 parentToLocalCoordinates (Entity childEntity, Vector2 parentCoords) {
-		TransformComponent trnasform = childEntity.getComponent(TransformComponent.class);
+		TransformComponent transform = childEntity.getComponent(TransformComponent.class);
 
-		final float rotation = trnasform.rotation;
-		final float scaleX = trnasform.scaleX;
-		final float scaleY = trnasform.scaleY;
-		final float childX = trnasform.x;
-		final float childY = trnasform.y;
+		final float rotation = transform.rotation;
+		final float scaleX = transform.scaleX;
+		final float scaleY = transform.scaleY;
+		final float childX = transform.x;
+		final float childY = transform.y;
 		if (rotation == 0) {
 			if (scaleX == 1 && scaleY == 1) {
 				parentCoords.x -= childX;


### PR DESCRIPTION
This PR is my second attempt to fix the issue #81 after the PR #88.

I followed your instructions to compute global coordinates recursively : 

> The way this properly should be fixed is - when positioning the box2d item in physics system, we should position it using not local coordinates, but global coordinates calculation (by recursively going up through parents)