### PR TITLE
Enable origin utilization in transform calculations

### DIFF
--- a/src/com/uwsoft/editor/renderer/components/TransformComponent.java
+++ b/src/com/uwsoft/editor/renderer/components/TransformComponent.java
@@ -10,6 +10,7 @@ public class TransformComponent implements Component {
 	public float rotation;
 	public float originX;
 	public float originY;
+	public boolean useOriginTransform = false;
 
 	private TransformComponent backup = null;
 
@@ -25,6 +26,7 @@ public class TransformComponent implements Component {
 		rotation = component.rotation;
 		originX = component.originX;
 		originY = component.originY;
+		useOriginTransform = component.useOriginTransform;
 	}
 
 	public void disableTransform() {
@@ -34,6 +36,7 @@ public class TransformComponent implements Component {
 		scaleX = 1f;
 		scaleY = 1f;
 		rotation = 0;
+		useOriginTransform = false;
 	}
 
 	public void enableTransform() {
@@ -45,6 +48,7 @@ public class TransformComponent implements Component {
 		rotation = backup.rotation;
 		originX = backup.originX;
 		originY = backup.originY;
+		useOriginTransform = backup.useOriginTransform;
 		backup = null;
 	}
 }

--- a/src/com/uwsoft/editor/renderer/systems/render/Overlap2dRenderer.java
+++ b/src/com/uwsoft/editor/renderer/systems/render/Overlap2dRenderer.java
@@ -196,9 +196,8 @@ public class Overlap2dRenderer extends IteratingSystem {
 		ParentNodeComponent parentNodeComponent = parentNodeMapper.get(rootEntity);
 		TransformComponent curTransform = transformMapper.get(rootEntity);
 		Affine2 worldTransform = curCompositeTransformComponent.worldTransform;
-		//TODO origin thing
-		float originX = 0;
-		float originY = 0;
+		float originX = curTransform.useOriginTransform ? curTransform.originX : 0;
+		float originY = curTransform.useOriginTransform ? curTransform.originY : 0;
 		float x = curTransform.x;
 		float y = curTransform.y;
 		float rotation = curTransform.rotation;


### PR DESCRIPTION
Backwards compatible. Defaults to false and uses (0,0) as origin.