### PR TITLE
Removed references to WeightedMeshAttachment

### DIFF
--- a/extensions/spine/src/com/overlap2d/extensions/spine/SpineObjectComponent.java
+++ b/extensions/spine/src/com/overlap2d/extensions/spine/SpineObjectComponent.java
@@ -6,7 +6,6 @@ import com.esotericsoftware.spine.*;
 import com.esotericsoftware.spine.attachments.Attachment;
 import com.esotericsoftware.spine.attachments.MeshAttachment;
 import com.esotericsoftware.spine.attachments.RegionAttachment;
-import com.esotericsoftware.spine.attachments.WeightedMeshAttachment;
 import com.uwsoft.editor.renderer.components.DimensionsComponent;
 
 public class SpineObjectComponent implements Component {
@@ -39,7 +38,7 @@ public class SpineObjectComponent implements Component {
             Slot slot = skeleton.getSlots().get(i);
             Attachment attachment = slot.getAttachment();
             if (attachment == null) continue;
-            if (!((attachment instanceof RegionAttachment) || (attachment instanceof MeshAttachment) || (attachment instanceof WeightedMeshAttachment))) continue;
+            if (!((attachment instanceof RegionAttachment) || (attachment instanceof MeshAttachment))) continue;
             float[] vertices = new float[0];
             if ((attachment instanceof RegionAttachment)) {
                 RegionAttachment region = (RegionAttachment) attachment;
@@ -48,11 +47,6 @@ public class SpineObjectComponent implements Component {
             }
             if ((attachment instanceof MeshAttachment)) {
                 MeshAttachment region = (MeshAttachment) attachment;
-                region.updateWorldVertices(slot, false);
-                vertices = region.getWorldVertices();
-            }
-            if ((attachment instanceof WeightedMeshAttachment)) {
-                WeightedMeshAttachment region = (WeightedMeshAttachment) attachment;
                 region.updateWorldVertices(slot, false);
                 vertices = region.getWorldVertices();
             }


### PR DESCRIPTION
WeightedMeshAttachment was deprecated, all functionality has been moved to MeshAttachment. (file won't compile with current spine library without this change)
